### PR TITLE
feat: add LightpandaFetcher as preferred JS-rendering backend

### DIFF
--- a/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
@@ -5,7 +5,6 @@ vi.mock('node:child_process', () => ({
   execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
     cb(null); // lightpanda version 성공
   },
-  promisify: (fn: unknown) => fn,
 }));
 
 vi.mock('node:util', () => ({

--- a/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// lightpanda 없음 → Playwright 사용 경로
+// lightpanda 있음 → LightpandaFetcher 사용 경로
 vi.mock('node:child_process', () => ({
   execFile: (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
-    cb(new Error('not found'));
+    cb(null); // lightpanda version 성공
   },
   promisify: (fn: unknown) => fn,
 }));
@@ -11,7 +11,7 @@ vi.mock('node:child_process', () => ({
 vi.mock('node:util', () => ({
   promisify: (fn: (...args: unknown[]) => void) =>
     (...args: unknown[]) =>
-      new Promise((_resolve, reject) => fn(...args, (err: Error | null) => err ? reject(err) : _resolve(undefined))),
+      new Promise((resolve, reject) => fn(...args, (err: Error | null) => err ? reject(err) : resolve(undefined))),
 }));
 
 vi.mock('../../fetcher/staticFetcher.js', () => ({
@@ -27,17 +27,12 @@ vi.mock('../../fetcher/lightpandaFetcher.js', () => ({
 }));
 
 import { createFetcher } from '../../fetcher/index.js';
-import { PlaywrightFetcher } from '../../fetcher/playwrightFetcher.js';
+import { LightpandaFetcher } from '../../fetcher/lightpandaFetcher.js';
 
-describe('createFetcher — lightpanda 없음, playwright 있음', () => {
-  it('Promise<HtmlFetcher>를 반환함', async () => {
+describe('createFetcher — lightpanda 있음', () => {
+  it('LightpandaFetcher를 최우선으로 반환', async () => {
     const fetcher = await createFetcher();
-    expect(typeof fetcher.fetch).toBe('function');
-  });
-
-  it('playwright 설치 환경에서 PlaywrightFetcher 반환', async () => {
-    const fetcher = await createFetcher();
-    expect(fetcher).toBeInstanceOf(PlaywrightFetcher);
+    expect(fetcher).toBeInstanceOf(LightpandaFetcher);
   });
 
   it('동일 인스턴스 반환 (memoized)', async () => {

--- a/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // lightpanda 있음 → LightpandaFetcher 사용 경로
 vi.mock('node:child_process', () => ({
-  execFile: (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+  execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
     cb(null); // lightpanda version 성공
   },
   promisify: (fn: unknown) => fn,

--- a/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.lightpanda.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // lightpanda 있음 → LightpandaFetcher 사용 경로
 vi.mock('node:child_process', () => ({
@@ -26,8 +26,10 @@ vi.mock('../../fetcher/lightpandaFetcher.js', () => ({
   LightpandaFetcher: class { fetch = vi.fn(); },
 }));
 
-import { createFetcher } from '../../fetcher/index.js';
+import { createFetcher, _resetFetcher } from '../../fetcher/index.js';
 import { LightpandaFetcher } from '../../fetcher/lightpandaFetcher.js';
+
+beforeEach(() => _resetFetcher());
 
 describe('createFetcher — lightpanda 있음', () => {
   it('LightpandaFetcher를 최우선으로 반환', async () => {

--- a/src/__tests__/fetcher/fetcherFactory.static.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.static.test.ts
@@ -1,6 +1,6 @@
 // lightpanda 없음 + playwright 없음 → StaticFetcher 사용 경로
 vi.mock('node:child_process', () => ({
-  execFile: (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+  execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
     cb(new Error('not found'));
   },
 }));

--- a/src/__tests__/fetcher/fetcherFactory.static.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.static.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../fetcher/lightpandaFetcher.js', () => ({
   LightpandaFetcher: class { fetch = vi.fn(); },
 }));
 
-vi.mock('playwright', () => { throw new Error('playwright not installed'); });
+vi.mock('playwright', async () => { throw new Error('playwright not installed'); });
 
 import { createFetcher, _resetFetcher } from '../../fetcher/index.js';
 import { StaticFetcher } from '../../fetcher/staticFetcher.js';

--- a/src/__tests__/fetcher/fetcherFactory.static.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.static.test.ts
@@ -1,0 +1,37 @@
+// lightpanda 없음 + playwright 없음 → StaticFetcher 사용 경로
+vi.mock('node:child_process', () => ({
+  execFile: (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+    cb(new Error('not found'));
+  },
+}));
+
+vi.mock('node:util', () => ({
+  promisify: (fn: (...args: unknown[]) => void) =>
+    (...args: unknown[]) =>
+      new Promise((_resolve, reject) => fn(...args, (err: Error | null) => err ? reject(err) : _resolve(undefined))),
+}));
+
+vi.mock('../../fetcher/staticFetcher.js', () => ({
+  StaticFetcher: class { fetch = vi.fn(); },
+}));
+
+vi.mock('../../fetcher/playwrightFetcher.js', () => ({
+  PlaywrightFetcher: class { fetch = vi.fn(); },
+}));
+
+vi.mock('../../fetcher/lightpandaFetcher.js', () => ({
+  LightpandaFetcher: class { fetch = vi.fn(); },
+}));
+
+vi.mock('playwright', () => { throw new Error('playwright not installed'); });
+
+import { describe, it, expect, vi } from 'vitest';
+import { createFetcher } from '../../fetcher/index.js';
+import { StaticFetcher } from '../../fetcher/staticFetcher.js';
+
+describe('createFetcher — lightpanda 없음, playwright 없음', () => {
+  it('StaticFetcher로 fallback', async () => {
+    const fetcher = await createFetcher();
+    expect(fetcher).toBeInstanceOf(StaticFetcher);
+  });
+});

--- a/src/__tests__/fetcher/fetcherFactory.static.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.static.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
 // lightpanda 없음 + playwright 없음 → StaticFetcher 사용 경로
 vi.mock('node:child_process', () => ({
   execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
@@ -25,7 +27,6 @@ vi.mock('../../fetcher/lightpandaFetcher.js', () => ({
 
 vi.mock('playwright', () => { throw new Error('playwright not installed'); });
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createFetcher, _resetFetcher } from '../../fetcher/index.js';
 import { StaticFetcher } from '../../fetcher/staticFetcher.js';
 

--- a/src/__tests__/fetcher/fetcherFactory.static.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.static.test.ts
@@ -25,9 +25,11 @@ vi.mock('../../fetcher/lightpandaFetcher.js', () => ({
 
 vi.mock('playwright', () => { throw new Error('playwright not installed'); });
 
-import { describe, it, expect, vi } from 'vitest';
-import { createFetcher } from '../../fetcher/index.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createFetcher, _resetFetcher } from '../../fetcher/index.js';
 import { StaticFetcher } from '../../fetcher/staticFetcher.js';
+
+beforeEach(() => _resetFetcher());
 
 describe('createFetcher — lightpanda 없음, playwright 없음', () => {
   it('StaticFetcher로 fallback', async () => {

--- a/src/__tests__/fetcher/fetcherFactory.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // lightpanda 없음 → Playwright 사용 경로
 vi.mock('node:child_process', () => ({
@@ -26,8 +26,10 @@ vi.mock('../../fetcher/lightpandaFetcher.js', () => ({
   LightpandaFetcher: class { fetch = vi.fn(); },
 }));
 
-import { createFetcher } from '../../fetcher/index.js';
+import { createFetcher, _resetFetcher } from '../../fetcher/index.js';
 import { PlaywrightFetcher } from '../../fetcher/playwrightFetcher.js';
+
+beforeEach(() => _resetFetcher());
 
 describe('createFetcher — lightpanda 없음, playwright 있음', () => {
   it('Promise<HtmlFetcher>를 반환함', async () => {

--- a/src/__tests__/fetcher/fetcherFactory.test.ts
+++ b/src/__tests__/fetcher/fetcherFactory.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // lightpanda 없음 → Playwright 사용 경로
 vi.mock('node:child_process', () => ({
-  execFile: (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+  execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
     cb(new Error('not found'));
   },
   promisify: (fn: unknown) => fn,

--- a/src/__tests__/fetcher/lightpandaFetcher.test.ts
+++ b/src/__tests__/fetcher/lightpandaFetcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { InvalidUrlError, FetchFailedError } from '../../utils/errors.js';
-import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES } from '../../config/constants.js';
+import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES, MAX_STDERR_BYTES } from '../../config/constants.js';
 
 vi.mock('node:dns/promises', () => ({
   resolve4: vi.fn().mockResolvedValue(['93.184.216.34']),
@@ -140,6 +140,25 @@ describe('LightpandaFetcher — 오류 처리', () => {
       fetcher.fetch('https://example.com'),
       emitError(new Error('ENOENT: lightpanda not found')),
     ])).rejects.toThrow(FetchFailedError);
+  });
+});
+
+describe('LightpandaFetcher — stderr 캡', () => {
+  it('MAX_STDERR_BYTES 초과 stderr는 잘려서 에러 메시지에 포함', async () => {
+    const oversizedStderr = 'x'.repeat(MAX_STDERR_BYTES + 1000);
+    const p = Promise.all([
+      fetcher.fetch('https://example.com'),
+      new Promise<void>(resolve => setTimeout(() => {
+        mockProc.stderr.emit('data', Buffer.from(oversizedStderr));
+        mockProc.emit('close', 1);
+        resolve();
+      }, 0)),
+    ]);
+    const err = await p.catch(e => e);
+    expect(err).toBeInstanceOf(FetchFailedError);
+    // 전체 stderr가 아닌 MAX_STDERR_BYTES만큼만 에러 메시지에 포함됨
+    expect(err.message).not.toContain(oversizedStderr);
+    expect(err.message.length).toBeLessThan(oversizedStderr.length);
   });
 });
 

--- a/src/__tests__/fetcher/lightpandaFetcher.test.ts
+++ b/src/__tests__/fetcher/lightpandaFetcher.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { InvalidUrlError, FetchFailedError } from '../../utils/errors.js';
+import { TIMEOUT_MS } from '../../config/constants.js';
 
 vi.mock('node:dns/promises', () => ({
   resolve4: vi.fn().mockResolvedValue(['93.184.216.34']),
@@ -127,5 +128,26 @@ describe('LightpandaFetcher — 오류 처리', () => {
       fetcher.fetch('https://example.com'),
       emitError(new Error('ENOENT: lightpanda not found')),
     ])).rejects.toThrow(FetchFailedError);
+  });
+});
+
+describe('LightpandaFetcher — 타임아웃', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('TIMEOUT_MS 초과 시 proc.kill 호출 후 FetchFailedError', async () => {
+    vi.useFakeTimers();
+
+    const fetchPromise = fetcher.fetch('https://example.com');
+
+    // t=0: DNS Promise.allSettled 마이크로태스크 완료 + spawn 후 타이머 등록 대기
+    await vi.advanceTimersByTimeAsync(0);
+
+    // TIMEOUT_MS 경과 → settle 콜백 실행
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS);
+
+    await expect(fetchPromise).rejects.toThrow(FetchFailedError);
+    expect(mockProc.kill).toHaveBeenCalledWith('SIGKILL');
   });
 });

--- a/src/__tests__/fetcher/lightpandaFetcher.test.ts
+++ b/src/__tests__/fetcher/lightpandaFetcher.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { InvalidUrlError, FetchFailedError } from '../../utils/errors.js';
+
+vi.mock('node:dns/promises', () => ({
+  resolve4: vi.fn().mockResolvedValue(['93.184.216.34']),
+  resolve6: vi.fn().mockRejectedValue(new Error('ENODATA')),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from 'node:child_process';
+import { LightpandaFetcher } from '../../fetcher/lightpandaFetcher.js';
+
+class MockProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+}
+
+let mockProc: MockProcess;
+const fetcher = new LightpandaFetcher();
+
+// setTimeout(fn, 0) ensures all pending microtasks (validateUrl's async DNS resolution)
+// complete before emitting, so proc event listeners are already attached.
+function emitSuccess(html: string): Promise<void> {
+  return new Promise(resolve => setTimeout(() => {
+    mockProc.stdout.emit('data', Buffer.from(html));
+    mockProc.emit('close', 0);
+    resolve();
+  }, 0));
+}
+
+function emitFailure(code: number, stderr = ''): Promise<void> {
+  return new Promise(resolve => setTimeout(() => {
+    if (stderr) mockProc.stderr.emit('data', Buffer.from(stderr));
+    mockProc.emit('close', code);
+    resolve();
+  }, 0));
+}
+
+function emitError(err: Error): Promise<void> {
+  return new Promise(resolve => setTimeout(() => {
+    mockProc.emit('error', err);
+    resolve();
+  }, 0));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockProc = new MockProcess();
+  vi.mocked(spawn).mockReturnValue(mockProc as unknown as ReturnType<typeof spawn>);
+});
+
+describe('LightpandaFetcher — 기본 동작', () => {
+  it('정상 URL에서 렌더링된 HTML 반환', async () => {
+    const html = '<html><body><h1>Hello</h1></body></html>';
+    const [result] = await Promise.all([
+      fetcher.fetch('https://example.com'),
+      emitSuccess(html),
+    ]);
+    expect(result).toBe(html);
+  });
+
+  it('올바른 lightpanda 인자로 spawn 호출', async () => {
+    await Promise.all([
+      fetcher.fetch('https://example.com'),
+      emitSuccess('<html></html>'),
+    ]);
+    expect(spawn).toHaveBeenCalledWith('lightpanda', [
+      'fetch',
+      '--dump', 'html',
+      '--strip-mode', 'js,css',
+      '--wait-until', 'domcontentloaded',
+      '--wait-ms', expect.any(String),
+      'https://example.com',
+    ]);
+  });
+
+  it('여러 stdout chunk를 이어붙여 반환', async () => {
+    const [result] = await Promise.all([
+      fetcher.fetch('https://example.com'),
+      new Promise<void>(resolve => setTimeout(() => {
+        mockProc.stdout.emit('data', Buffer.from('<html>'));
+        mockProc.stdout.emit('data', Buffer.from('<body>hi</body>'));
+        mockProc.stdout.emit('data', Buffer.from('</html>'));
+        mockProc.emit('close', 0);
+        resolve();
+      }, 0)),
+    ]);
+    expect(result).toBe('<html><body>hi</body></html>');
+  });
+});
+
+describe('LightpandaFetcher — SSRF 차단', () => {
+  it('사설 IP URL은 InvalidUrlError', async () => {
+    await expect(fetcher.fetch('http://127.0.0.1')).rejects.toThrow(InvalidUrlError);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('2048자 초과 URL은 InvalidUrlError', async () => {
+    const longUrl = 'https://example.com/?' + 'a'.repeat(2050);
+    await expect(fetcher.fetch(longUrl)).rejects.toThrow(InvalidUrlError);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});
+
+describe('LightpandaFetcher — 오류 처리', () => {
+  it('비정상 종료 코드(non-zero)는 FetchFailedError', async () => {
+    await expect(Promise.all([
+      fetcher.fetch('https://example.com'),
+      emitFailure(1, 'something went wrong'),
+    ])).rejects.toThrow(FetchFailedError);
+  });
+
+  it('stderr 내용이 없어도 FetchFailedError 발생', async () => {
+    await expect(Promise.all([
+      fetcher.fetch('https://example.com'),
+      emitFailure(1),
+    ])).rejects.toThrow(FetchFailedError);
+  });
+
+  it('spawn 자체 오류(ENOENT 등)는 FetchFailedError', async () => {
+    await expect(Promise.all([
+      fetcher.fetch('https://example.com'),
+      emitError(new Error('ENOENT: lightpanda not found')),
+    ])).rejects.toThrow(FetchFailedError);
+  });
+});

--- a/src/__tests__/fetcher/lightpandaFetcher.test.ts
+++ b/src/__tests__/fetcher/lightpandaFetcher.test.ts
@@ -22,6 +22,8 @@ class MockProcess extends EventEmitter {
 }
 
 let mockProc: MockProcess;
+// LightpandaFetcher has no internal state — singleton is safe across tests.
+// Re-create here if stateful fields are added in the future.
 const fetcher = new LightpandaFetcher();
 
 // setTimeout(fn, 0) ensures all pending microtasks (validateUrl's async DNS resolution)

--- a/src/__tests__/fetcher/lightpandaFetcher.test.ts
+++ b/src/__tests__/fetcher/lightpandaFetcher.test.ts
@@ -109,10 +109,23 @@ describe('LightpandaFetcher — SSRF 차단', () => {
 });
 
 describe('LightpandaFetcher — 크기 제한', () => {
-  it('MAX_BODY_SIZE_BYTES 초과 시 FetchFailedError + proc.kill 호출', async () => {
+  it('단일 청크로 MAX_BODY_SIZE_BYTES 초과 시 FetchFailedError + proc.kill 호출', async () => {
     const fetchPromise = fetcher.fetch('https://example.com');
     await new Promise<void>(resolve => setTimeout(() => {
       mockProc.stdout.emit('data', Buffer.alloc(MAX_BODY_SIZE_BYTES + 1));
+      resolve();
+    }, 0));
+    await expect(fetchPromise).rejects.toThrow(FetchFailedError);
+    expect(mockProc.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('여러 청크 누적으로 MAX_BODY_SIZE_BYTES 초과 시 FetchFailedError + proc.kill 호출', async () => {
+    const fetchPromise = fetcher.fetch('https://example.com');
+    await new Promise<void>(resolve => setTimeout(() => {
+      const halfSize = Math.floor(MAX_BODY_SIZE_BYTES / 2);
+      mockProc.stdout.emit('data', Buffer.alloc(halfSize));
+      mockProc.stdout.emit('data', Buffer.alloc(halfSize));
+      mockProc.stdout.emit('data', Buffer.alloc(halfSize)); // 세 번째로 초과
       resolve();
     }, 0));
     await expect(fetchPromise).rejects.toThrow(FetchFailedError);

--- a/src/__tests__/fetcher/lightpandaFetcher.test.ts
+++ b/src/__tests__/fetcher/lightpandaFetcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { InvalidUrlError, FetchFailedError } from '../../utils/errors.js';
-import { TIMEOUT_MS } from '../../config/constants.js';
+import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES } from '../../config/constants.js';
 
 vi.mock('node:dns/promises', () => ({
   resolve4: vi.fn().mockResolvedValue(['93.184.216.34']),
@@ -105,6 +105,18 @@ describe('LightpandaFetcher — SSRF 차단', () => {
     const longUrl = 'https://example.com/?' + 'a'.repeat(2050);
     await expect(fetcher.fetch(longUrl)).rejects.toThrow(InvalidUrlError);
     expect(spawn).not.toHaveBeenCalled();
+  });
+});
+
+describe('LightpandaFetcher — 크기 제한', () => {
+  it('MAX_BODY_SIZE_BYTES 초과 시 FetchFailedError + proc.kill 호출', async () => {
+    const fetchPromise = fetcher.fetch('https://example.com');
+    await new Promise<void>(resolve => setTimeout(() => {
+      mockProc.stdout.emit('data', Buffer.alloc(MAX_BODY_SIZE_BYTES + 1));
+      resolve();
+    }, 0));
+    await expect(fetchPromise).rejects.toThrow(FetchFailedError);
+    expect(mockProc.kill).toHaveBeenCalledWith('SIGKILL');
   });
 });
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,4 +2,5 @@ export const MAX_URL_LENGTH = 2048;
 export const TIMEOUT_MS = 15_000;
 export const MAX_BODY_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
 export const MAX_STDERR_BYTES = 64 * 1024; // 64KB
+export const LIGHTPANDA_STRIP_MODE = 'js,css';
 export const USER_AGENT = 'Mozilla/5.0 (compatible; web2md/1.0)';

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,5 @@
 export const MAX_URL_LENGTH = 2048;
 export const TIMEOUT_MS = 15_000;
 export const MAX_BODY_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+export const MAX_STDERR_BYTES = 64 * 1024; // 64KB
 export const USER_AGENT = 'Mozilla/5.0 (compatible; web2md/1.0)';

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -32,6 +32,7 @@ function buildFetcher(): Promise<HtmlFetcher> {
         return new PlaywrightFetcher() as HtmlFetcher;
       });
     })
+    // Playwright unavailable (not installed or Chromium missing) → fall back to static.
     .catch(() => new StaticFetcher());
 }
 

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -17,22 +17,32 @@ async function isLightpandaAvailable(): Promise<boolean> {
   }
 }
 
-// Probe once at module load; result is memoized for all subsequent calls.
 // Priority: Lightpanda > Playwright/Chromium > Static
-const _fetcher: Promise<HtmlFetcher> = isLightpandaAvailable()
-  .then((available) => {
-    if (available) return new LightpandaFetcher() as HtmlFetcher;
-    return import('playwright').then(({ chromium }) => {
-      if (!existsSync(chromium.executablePath())) {
-        throw new Error('Chromium not installed');
-      }
-      return new PlaywrightFetcher() as HtmlFetcher;
-    });
-  })
-  .catch(() => new StaticFetcher());
+// Resolved lazily on first call; subsequent calls return the memoized promise.
+let _fetcher: Promise<HtmlFetcher> | null = null;
+
+function buildFetcher(): Promise<HtmlFetcher> {
+  return isLightpandaAvailable()
+    .then((available) => {
+      if (available) return new LightpandaFetcher() as HtmlFetcher;
+      return import('playwright').then(({ chromium }) => {
+        if (!existsSync(chromium.executablePath())) {
+          throw new Error('Chromium not installed');
+        }
+        return new PlaywrightFetcher() as HtmlFetcher;
+      });
+    })
+    .catch(() => new StaticFetcher());
+}
 
 export function createFetcher(): Promise<HtmlFetcher> {
+  if (!_fetcher) _fetcher = buildFetcher();
   return _fetcher;
+}
+
+/** Reset memoized fetcher — for use in tests only. */
+export function _resetFetcher(): void {
+  _fetcher = null;
 }
 
 export type { HtmlFetcher };

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -10,7 +10,7 @@ const execFileAsync = promisify(execFile);
 
 async function isLightpandaAvailable(): Promise<boolean> {
   try {
-    await execFileAsync('lightpanda', ['version']);
+    await execFileAsync('lightpanda', ['version'], { timeout: 3_000 });
     return true;
   } catch {
     return false;

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -1,16 +1,33 @@
 import { existsSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { StaticFetcher } from './staticFetcher.js';
 import { PlaywrightFetcher } from './playwrightFetcher.js';
+import { LightpandaFetcher } from './lightpandaFetcher.js';
 import type { HtmlFetcher } from './types.js';
 
+const execFileAsync = promisify(execFile);
+
+async function isLightpandaAvailable(): Promise<boolean> {
+  try {
+    await execFileAsync('lightpanda', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Probe once at module load; result is memoized for all subsequent calls.
-// Checks both: (1) playwright npm package importable, (2) Chromium binary exists.
-const _fetcher: Promise<HtmlFetcher> = import('playwright')
-  .then(({ chromium }) => {
-    if (!existsSync(chromium.executablePath())) {
-      throw new Error('Chromium not installed');
-    }
-    return new PlaywrightFetcher() as HtmlFetcher;
+// Priority: Lightpanda > Playwright/Chromium > Static
+const _fetcher: Promise<HtmlFetcher> = isLightpandaAvailable()
+  .then((available) => {
+    if (available) return new LightpandaFetcher() as HtmlFetcher;
+    return import('playwright').then(({ chromium }) => {
+      if (!existsSync(chromium.executablePath())) {
+        throw new Error('Chromium not installed');
+      }
+      return new PlaywrightFetcher() as HtmlFetcher;
+    });
   })
   .catch(() => new StaticFetcher());
 

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -10,7 +10,7 @@ const execFileAsync = promisify(execFile);
 
 async function isLightpandaAvailable(): Promise<boolean> {
   try {
-    await execFileAsync('lightpanda', ['--version']);
+    await execFileAsync('lightpanda', ['version']);
     return true;
   } catch {
     return false;

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -35,6 +35,7 @@ export class LightpandaFetcher implements HtmlFetcher {
 
       const settleError = (fn: () => void) => settle(() => {
         chunks.length = 0;
+        errChunks.length = 0;
         fn();
       });
 
@@ -70,15 +71,14 @@ export class LightpandaFetcher implements HtmlFetcher {
         errSize += toStore.length;
       });
 
-      proc.on('close', (code) => settle(() => {
+      proc.on('close', (code) => {
         if (code === 0) {
-          resolve(Buffer.concat(chunks).toString('utf-8'));
+          settle(() => resolve(Buffer.concat(chunks).toString('utf-8')));
         } else {
-          chunks.length = 0;
           const stderr = Buffer.concat(errChunks).toString('utf-8');
-          reject(new FetchFailedError(url, new Error(stderr || `lightpanda exited with code ${code}`)));
+          settleError(() => reject(new FetchFailedError(url, new Error(stderr || `lightpanda exited with code ${code}`))));
         }
-      }));
+      });
 
       proc.on('error', (e) => settleError(() => reject(new FetchFailedError(url, e))));
     });

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -1,0 +1,49 @@
+import { spawn } from 'node:child_process';
+import { validateUrl } from '../utils/ssrf.js';
+import { FetchFailedError, InvalidUrlError } from '../utils/errors.js';
+import { MAX_URL_LENGTH, TIMEOUT_MS } from '../config/constants.js';
+import type { HtmlFetcher } from './types.js';
+
+export class LightpandaFetcher implements HtmlFetcher {
+  async fetch(url: string): Promise<string> {
+    if (url.length > MAX_URL_LENGTH) throw new InvalidUrlError(url);
+    await validateUrl(url);
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn('lightpanda', [
+        'fetch',
+        '--dump', 'html',
+        '--strip-mode', 'js,css',
+        '--wait-until', 'domcontentloaded',
+        '--wait-ms', String(TIMEOUT_MS),
+        url,
+      ]);
+
+      const chunks: Buffer[] = [];
+      const errChunks: Buffer[] = [];
+
+      proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+      proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
+
+      const timer = setTimeout(() => {
+        proc.kill();
+        reject(new FetchFailedError(url, new Error('lightpanda fetch timed out')));
+      }, TIMEOUT_MS + 2_000);
+
+      proc.on('close', (code) => {
+        clearTimeout(timer);
+        if (code === 0) {
+          resolve(Buffer.concat(chunks).toString('utf-8'));
+        } else {
+          const stderr = Buffer.concat(errChunks).toString('utf-8');
+          reject(new FetchFailedError(url, new Error(stderr || `lightpanda exited with code ${code}`)));
+        }
+      });
+
+      proc.on('error', (e) => {
+        clearTimeout(timer);
+        reject(new FetchFailedError(url, e));
+      });
+    });
+  }
+}

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { validateUrl } from '../utils/ssrf.js';
 import { FetchFailedError } from '../utils/errors.js';
-import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES, MAX_STDERR_BYTES } from '../config/constants.js';
+import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES, MAX_STDERR_BYTES, LIGHTPANDA_STRIP_MODE } from '../config/constants.js';
 import type { HtmlFetcher } from './types.js';
 
 export class LightpandaFetcher implements HtmlFetcher {
@@ -12,7 +12,7 @@ export class LightpandaFetcher implements HtmlFetcher {
       const proc = spawn('lightpanda', [
         'fetch',
         '--dump', 'html',
-        '--strip-mode', 'js,css',
+        '--strip-mode', LIGHTPANDA_STRIP_MODE,
         '--wait-until', 'domcontentloaded',
         '--wait-ms', String(Math.max(TIMEOUT_MS - 3_000, 1_000)),
         url,

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { validateUrl } from '../utils/ssrf.js';
 import { FetchFailedError } from '../utils/errors.js';
-import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES } from '../config/constants.js';
+import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES, MAX_STDERR_BYTES } from '../config/constants.js';
 import type { HtmlFetcher } from './types.js';
 
 export class LightpandaFetcher implements HtmlFetcher {
@@ -22,8 +22,7 @@ export class LightpandaFetcher implements HtmlFetcher {
       const errChunks: Buffer[] = [];
       let totalSize = 0;
       let errSize = 0;
-      const MAX_STDERR_BYTES = 64 * 1024;
-      let timer: ReturnType<typeof setTimeout>;
+      let timer: ReturnType<typeof setTimeout> | undefined;
       let settled = false;
 
       const settle = (fn: () => void) => {

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -1,12 +1,11 @@
 import { spawn } from 'node:child_process';
 import { validateUrl } from '../utils/ssrf.js';
-import { FetchFailedError, InvalidUrlError } from '../utils/errors.js';
-import { MAX_URL_LENGTH, TIMEOUT_MS, MAX_BODY_SIZE_BYTES } from '../config/constants.js';
+import { FetchFailedError } from '../utils/errors.js';
+import { TIMEOUT_MS, MAX_BODY_SIZE_BYTES } from '../config/constants.js';
 import type { HtmlFetcher } from './types.js';
 
 export class LightpandaFetcher implements HtmlFetcher {
   async fetch(url: string): Promise<string> {
-    if (url.length > MAX_URL_LENGTH) throw new InvalidUrlError(url);
     await validateUrl(url);
 
     return new Promise((resolve, reject) => {

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -33,8 +33,16 @@ export class LightpandaFetcher implements HtmlFetcher {
         fn();
       };
 
+      const killProc = () => {
+        try {
+          proc.kill('SIGKILL');
+        } catch (e: unknown) {
+          if ((e as NodeJS.ErrnoException).code !== 'ESRCH') throw e;
+        }
+      };
+
       timer = setTimeout(() => settle(() => {
-        try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+        killProc();
         reject(new FetchFailedError(url, new Error('lightpanda fetch timed out')));
       }), TIMEOUT_MS);
 
@@ -42,7 +50,7 @@ export class LightpandaFetcher implements HtmlFetcher {
         totalSize += chunk.length;
         if (totalSize > MAX_BODY_SIZE_BYTES) {
           settle(() => {
-            try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+            killProc();
             reject(new FetchFailedError(url, new Error('Response too large')));
           });
           return;

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -21,6 +21,8 @@ export class LightpandaFetcher implements HtmlFetcher {
       const chunks: Buffer[] = [];
       const errChunks: Buffer[] = [];
       let totalSize = 0;
+      let errSize = 0;
+      const MAX_STDERR_BYTES = 64 * 1024;
       let timer: ReturnType<typeof setTimeout>;
       let settled = false;
 
@@ -47,7 +49,12 @@ export class LightpandaFetcher implements HtmlFetcher {
         }
         chunks.push(chunk);
       });
-      proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
+      proc.stderr.on('data', (chunk: Buffer) => {
+        const remaining = MAX_STDERR_BYTES - errSize;
+        if (remaining <= 0) return;
+        errChunks.push(chunk.subarray(0, remaining));
+        errSize += chunk.length;
+      });
 
       proc.on('close', (code) => settle(() => {
         if (code === 0) {

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -59,8 +59,9 @@ export class LightpandaFetcher implements HtmlFetcher {
       proc.stderr.on('data', (chunk: Buffer) => {
         const remaining = MAX_STDERR_BYTES - errSize;
         if (remaining <= 0) return;
-        errChunks.push(chunk.subarray(0, remaining));
-        errSize += chunk.length;
+        const toStore = chunk.subarray(0, remaining);
+        errChunks.push(toStore);
+        errSize += toStore.length;
       });
 
       proc.on('close', (code) => settle(() => {

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -14,6 +14,7 @@ export class LightpandaFetcher implements HtmlFetcher {
         '--dump', 'html',
         '--strip-mode', LIGHTPANDA_STRIP_MODE,
         '--wait-until', 'domcontentloaded',
+        // 3s margin so lightpanda times out before Node kills the process; minimum 1s
         '--wait-ms', String(Math.max(TIMEOUT_MS - 3_000, 1_000)),
         url,
       ]);
@@ -32,6 +33,11 @@ export class LightpandaFetcher implements HtmlFetcher {
         fn();
       };
 
+      const settleError = (fn: () => void) => settle(() => {
+        chunks.length = 0;
+        fn();
+      });
+
       const killProc = () => {
         try {
           proc.kill('SIGKILL');
@@ -40,7 +46,7 @@ export class LightpandaFetcher implements HtmlFetcher {
         }
       };
 
-      timer = setTimeout(() => settle(() => {
+      timer = setTimeout(() => settleError(() => {
         killProc();
         reject(new FetchFailedError(url, new Error('lightpanda fetch timed out')));
       }), TIMEOUT_MS);
@@ -48,7 +54,7 @@ export class LightpandaFetcher implements HtmlFetcher {
       proc.stdout.on('data', (chunk: Buffer) => {
         totalSize += chunk.length;
         if (totalSize > MAX_BODY_SIZE_BYTES) {
-          settle(() => {
+          settleError(() => {
             killProc();
             reject(new FetchFailedError(url, new Error('Response too large')));
           });
@@ -68,12 +74,13 @@ export class LightpandaFetcher implements HtmlFetcher {
         if (code === 0) {
           resolve(Buffer.concat(chunks).toString('utf-8'));
         } else {
+          chunks.length = 0;
           const stderr = Buffer.concat(errChunks).toString('utf-8');
           reject(new FetchFailedError(url, new Error(stderr || `lightpanda exited with code ${code}`)));
         }
       }));
 
-      proc.on('error', (e) => settle(() => reject(new FetchFailedError(url, e))));
+      proc.on('error', (e) => settleError(() => reject(new FetchFailedError(url, e))));
     });
   }
 }

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -15,7 +15,7 @@ export class LightpandaFetcher implements HtmlFetcher {
         '--dump', 'html',
         '--strip-mode', 'js,css',
         '--wait-until', 'domcontentloaded',
-        '--wait-ms', String(TIMEOUT_MS),
+        '--wait-ms', String(Math.max(TIMEOUT_MS - 3_000, 1_000)),
         url,
       ]);
 
@@ -35,7 +35,7 @@ export class LightpandaFetcher implements HtmlFetcher {
       timer = setTimeout(() => settle(() => {
         try { proc.kill('SIGKILL'); } catch { /* already gone */ }
         reject(new FetchFailedError(url, new Error('lightpanda fetch timed out')));
-      }), TIMEOUT_MS + 2_000);
+      }), TIMEOUT_MS);
 
       proc.stdout.on('data', (chunk: Buffer) => {
         totalSize += chunk.length;

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -25,25 +25,31 @@ export class LightpandaFetcher implements HtmlFetcher {
       proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
       proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
 
-      const timer = setTimeout(() => {
-        proc.kill();
-        reject(new FetchFailedError(url, new Error('lightpanda fetch timed out')));
-      }, TIMEOUT_MS + 2_000);
+      let timer: ReturnType<typeof setTimeout>;
+      let settled = false;
 
-      proc.on('close', (code) => {
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
+        fn();
+      };
+
+      timer = setTimeout(() => settle(() => {
+        try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+        reject(new FetchFailedError(url, new Error('lightpanda fetch timed out')));
+      }), TIMEOUT_MS + 2_000);
+
+      proc.on('close', (code) => settle(() => {
         if (code === 0) {
           resolve(Buffer.concat(chunks).toString('utf-8'));
         } else {
           const stderr = Buffer.concat(errChunks).toString('utf-8');
           reject(new FetchFailedError(url, new Error(stderr || `lightpanda exited with code ${code}`)));
         }
-      });
+      }));
 
-      proc.on('error', (e) => {
-        clearTimeout(timer);
-        reject(new FetchFailedError(url, e));
-      });
+      proc.on('error', (e) => settle(() => reject(new FetchFailedError(url, e))));
     });
   }
 }

--- a/src/fetcher/lightpandaFetcher.ts
+++ b/src/fetcher/lightpandaFetcher.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { validateUrl } from '../utils/ssrf.js';
 import { FetchFailedError, InvalidUrlError } from '../utils/errors.js';
-import { MAX_URL_LENGTH, TIMEOUT_MS } from '../config/constants.js';
+import { MAX_URL_LENGTH, TIMEOUT_MS, MAX_BODY_SIZE_BYTES } from '../config/constants.js';
 import type { HtmlFetcher } from './types.js';
 
 export class LightpandaFetcher implements HtmlFetcher {
@@ -21,10 +21,7 @@ export class LightpandaFetcher implements HtmlFetcher {
 
       const chunks: Buffer[] = [];
       const errChunks: Buffer[] = [];
-
-      proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
-      proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
-
+      let totalSize = 0;
       let timer: ReturnType<typeof setTimeout>;
       let settled = false;
 
@@ -39,6 +36,19 @@ export class LightpandaFetcher implements HtmlFetcher {
         try { proc.kill('SIGKILL'); } catch { /* already gone */ }
         reject(new FetchFailedError(url, new Error('lightpanda fetch timed out')));
       }), TIMEOUT_MS + 2_000);
+
+      proc.stdout.on('data', (chunk: Buffer) => {
+        totalSize += chunk.length;
+        if (totalSize > MAX_BODY_SIZE_BYTES) {
+          settle(() => {
+            try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+            reject(new FetchFailedError(url, new Error('Response too large')));
+          });
+          return;
+        }
+        chunks.push(chunk);
+      });
+      proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
 
       proc.on('close', (code) => settle(() => {
         if (code === 0) {


### PR DESCRIPTION
## Summary

- `lightpanda fetch --dump html` CLI를 `child_process.spawn`으로 호출하는 `LightpandaFetcher` 추가
- 팩토리 폴백 체인을 **Lightpanda → Playwright/Chromium → Static** 순으로 변경
- `lightpanda` 바이너리가 PATH에 없으면 기존 동작 그대로 유지

## 동작 방식

`lightpanda` 바이너리가 감지되면 다음 명령을 실행합니다:

```
lightpanda fetch --dump html --strip-mode js,css --wait-until domcontentloaded --wait-ms 15000 <url>
```

- `--dump html`: JS 실행 후 렌더링된 HTML을 stdout으로 출력
- `--strip-mode js,css`: script/style 태그 제거 (마크다운 변환에 불필요)
- SSRF 검증은 기존 `validateUrl()` 그대로 적용
- 프로세스 타임아웃은 `TIMEOUT_MS + 2초` 여유를 두고 강제 종료

## 기대 효과 (vs Chromium)

| | Lightpanda | Chromium |
|---|---|---|
| 실행 속도 | ~9x 빠름 | 기준 |
| 메모리 | ~16x 낮음 | 기준 |
| 설치 | 단일 바이너리 | playwright install 필요 |

## 설치 방법

```bash
# macOS (aarch64)
curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/nightly/lightpanda-aarch64-macos
chmod +x lightpanda && sudo mv lightpanda /usr/local/bin/
```

## Test plan

- [ ] `lightpanda` 바이너리 있을 때 `LightpandaFetcher`가 선택되는지 확인
- [ ] `lightpanda` 없을 때 기존 폴백 체인이 유지되는지 확인
- [ ] JS 렌더링이 필요한 페이지에서 HTML이 정상 반환되는지 확인
- [ ] 잘못된 URL/타임아웃 시 `FetchFailedError`가 throw되는지 확인

> **Note**: Lightpanda는 현재 beta로 CORS 미지원 등 일부 제약이 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)